### PR TITLE
Using webhook script instead of CircleCI notify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ jobs:
           path: wp-e2e-tests/reports/
       - store_artifacts:
           path: wp-e2e-tests/screenshots/
-notify:
-  webhooks:
-    - url: https://a8c-gh-e2e-bridge.go-vip.co/circleciwebhook
+      - run:
+          name: Notify webhook of failed build
+          when: on_fail
+          command: ./wp-e2e-tests/scripts/notify-webhook.sh failed
+      - run:
+          name: Notify webhook of successful build
+          when: on_success
+          command: ./wp-e2e-tests/scripts/notify-webhook.sh success


### PR DESCRIPTION
This will use a script to return build results to GitHub instead of the unreliable CircleCI notify functionality

To Test:

Run wp-e2e-tests-gh-bridge locally after making sure that `E2E_WRAPPER_BRANCH` environment variable is set to `try/webhook-script`
Post a PR payload to the local instance
Confirm that after the tests complete, the results show up on the PR in GitHub

part of https://github.com/Automattic/wp-e2e-tests/issues/1668