### PR TITLE
Updating to handle e2e test running matching calypso branches

### DIFF
--- a/wait-for-running-branch.sh
+++ b/wait-for-running-branch.sh
@@ -5,6 +5,12 @@ if [ "" == "$sha" ]; then
   exit;
 fi
 
+if [ "$sha" != "$calypsoSha" ]; then
+    echo "Using calypsoSha envvar"
+    sha=$calypsoSha
+    exit;
+fi
+
 COUNT=0
 RESETCOUNT=60 # 5sec retry = Reset the branch after 5 minutes
 MAXCOUNT=120  # 5sec retry = Cancel after 10 minutes


### PR DESCRIPTION
This will still work if just the sha envvar is available, but if the calypsoSha envvar is also available, then use that instead. This is to support Automattic/wp-e2e-tests#1549

Test instructions will be in a related PR