### PR TITLE
Update to read chromedriver version from file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,9 @@ jobs:
             - v1-npmcache-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/test/e2e/package.json" }}
             - v1-npmcache-{{ checksum "wp-calypso/.nvmrc" }}
             - v1-npmcache
-      - run: cd wp-calypso/test/e2e && npm ci
+      - run: |
+          cd wp-calypso/test/e2e &&
+          CHROMEDRIVER_VERSION=$(<.chromedriver_version) npm ci
       - save_cache:
           key: v1-npmcache-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/test/e2e/package.json" }}
           paths:


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/34238

This will have the config read the chromedriver version from a file so that it stays in sync with wp-calypso